### PR TITLE
adjust uuidgen for Darwin platforms

### DIFF
--- a/kubectl-enter
+++ b/kubectl-enter
@@ -4,9 +4,15 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+if [ $(uname) = "Linux" ]; then
+  UUID="$(uuidgen)"
+elif [ $(uname) = "Darwin" ]; then
+  UUID="$(uuidgen | tr "[:upper:]" "[:lower:]")"
+fi
+
 NODE="$1"
 IMAGE="alpine"
-POD="nsenter-$(uuidgen | cut -d- -f1)"
+POD="nsenter-$(echo $UUID | cut -d- -f1)"
 NAMESPACE=""
 
 # Check the node


### PR DESCRIPTION
To overcome the issue with uppercase UUID on MacOS:
```
The Pod "nsenter-592A1B1A" is invalid: metadata.name: Invalid value: "nsenter-592A1B1A": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```